### PR TITLE
Fix the lint-docs status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DinoWorld
 
-[![lint-docs](https://github.com/dchenbecker/dinoworld/actions/workflows/lint-docs.yml/badge.svg)](https://github.com/dchenbecker/dinoworld/actions/workflows/lint-docs.yml)
+[![lint-docs](https://github.com/JMS1138/dinoworld/actions/workflows/lint-docs.yml/badge.svg)](https://github.com/JMS1138/dinoworld/actions/workflows/lint-docs.yml)
 
 DinoWorld is a project to try and learn about the Godot engine, game
 development, development processes, and have a lot of fun along the way!


### PR DESCRIPTION
Prior to the initial merge, this was pointing at my personal fork, but now that the action has been merged to the primary fork, we should update the badge.