### PR TITLE
Add documentation and setup for initial development

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,7 @@ development, development processes, and have a lot of fun along the way!
 
 ## Building
 
-In order to build DinoWorld, you will need the following tools:
-
-- Godot (≥ 4.2)
-- asdf for management of various tools we use to build things
-
-## Contributing
-
-TODO
+See [the dev docs](file:./docs/Dev Resources and Info.md)
 
 ## Authors
 

--- a/docs/Dev Resources and Info.md
+++ b/docs/Dev Resources and Info.md
@@ -3,6 +3,28 @@
 This document is a place (dumping ground?) for interesting articles and other
 information on game development.
 
+## Initial Setup
+
+In order to get started on development, you need to install a few things:
+
+- [ASDF](https://asdf-vm.com/guide/getting-started.html), a tool for managing
+  other dev tools
+- [Godot Engine](https://godotengine.org/download/) ≥ 4.2. make sure to get the
+  `.Net` version
+
+In the project root, install all of the tooling dependencies with:
+
+``` bash
+asdf install
+```
+
+Next, we set up some custom githooks to help with development, so you need to
+configure `git` to use them:
+
+``` bash
+git config --local core.hooksPath tools/githooks/
+```
+
 ## Build Tooling and Processes
 
 - https://blog.codemagic.io/godot-games-cicd/

--- a/tools/githooks/pre-commit
+++ b/tools/githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Propagate any failures in the script
+set -o errexit
+
+# If any of the files being checked in are Markdown, we need to lint them before committing
+if git diff --cached --name-only --diff-filter=ACM | grep -qE '\.md$'; then
+    markdownlint-cli2 *.md **/*.md
+fi
+


### PR DESCRIPTION
- Rearrange dev docs into their own file so it doesn't clutter the README
- Create a git hook to lint Markdown files along with instructions for setup